### PR TITLE
Cap updates

### DIFF
--- a/siff-dr/siff-header.go
+++ b/siff-dr/siff-header.go
@@ -35,11 +35,18 @@ func setSiffFields(packet *netfilter.NFPacket, flags layers.IPv4Flag, capabiliti
 	}
 
 	/* Modify the ip layer information */
+	var IHLchange uint16 = uint16((*ipLayer).IHL)
+
 	// compute new IHL and length
 	if (flags & 0x03) == IS_SIFF {
 		(*ipLayer).IHL = 7
 	} else if (flags & 0x03) == (IS_SIFF | CAPABILITY_UPDATE) {
 		(*ipLayer).IHL = 9
+	}
+
+	IHLchange = uint16((*ipLayer).IHL) - IHLchange
+	if IHLchange != 0 {
+		(*ipLayer).Length = (*ipLayer).Length + IHLchange * 4
 	}
 
 	/* change the total length by the change in IHL * 4 to convert from

--- a/siff-dr/siff-header.go
+++ b/siff-dr/siff-header.go
@@ -58,8 +58,11 @@ func setSiffFields(packet *netfilter.NFPacket, flags layers.IPv4Flag, capabiliti
 	var capOption layers.IPv4Option
 	capOption.OptionType = 86
 	capOption.OptionLength = uint8(len(capabilities)) + 2
-	capabilities = append(capabilities, 0)
-	capabilities = append(capabilities, 0)
+	// If packet sent contains only capabilities, requires padding
+	if (uint8(flags) & 0x3) != uint8(IS_SIFF|CAPABILITY_UPDATE) {
+		capabilities = append(capabilities, 0)
+		capabilities = append(capabilities, 0)
+	}
 	capOption.OptionData = capabilities
 
 	var updateOption layers.IPv4Option

--- a/siff-dr/siff-header.go
+++ b/siff-dr/siff-header.go
@@ -41,30 +41,44 @@ func setSiffFields(packet *netfilter.NFPacket, flags layers.IPv4Flag, capabiliti
 	if (flags & 0x03) == IS_SIFF {
 		(*ipLayer).IHL = 7
 	} else if (flags & 0x03) == (IS_SIFF | CAPABILITY_UPDATE) {
-		(*ipLayer).IHL = 8
+		(*ipLayer).IHL = 9
 	}
 
 	/* change the total length by the change in IHL * 4 to convert from
 	   32-bit words to bytes */
 	IHLchange = (*ipLayer).IHL - IHLchange
 	if IHLchange != 0 {
-		(*ipLayer).Length = (*ipLayer).Length + uint16(IHLchange)*4
+		(*ipLayer).Length = uint16((*ipLayer).IHL) * 4
 	}
 
 	// set the flags, preserving the first flag bit in case it is used
-	(*ipLayer).Flags = flags
+	(*ipLayer).IHL = flags
 
 	// handle the options
 	var capOption layers.IPv4Option
 	capOption.OptionType = 86
-	capOption.OptionLength = uint8(len(capabilities)) + 2
-	capabilities = append(capabilities, 0)
-	capabilities = append(capabilities, 0)
-	capOption.OptionData = capabilities
+	capOption.OptionLength = 8
+	var capabilities_array [6]byte
+	for i, b := range capabilities {
+		capabilities_array[i] = b
+	}
+	for i := len(capabilities); i < 6; i++ {
+		capabilities_array[i] = 0
+	}
+	capOption.OptionData = capabilities_array[:]
 
 	var updateOption layers.IPv4Option
 	updateOption.OptionType = 86
-	updateOption.OptionLength = uint8(len(updoots))
+	updateOption.OptionLength = 8
+
+	var updates_array [6]byte
+	for i, b := range updoots {
+		updates_array[i] = b
+	}
+	for i := len(updoots); i < 6; i++ {
+		updates_array[i] = 0
+	}
+
 	updateOption.OptionData = updoots
 
 	optionArray[0] = capOption
@@ -72,7 +86,7 @@ func setSiffFields(packet *netfilter.NFPacket, flags layers.IPv4Flag, capabiliti
 
 	// add options
 	if (uint8(flags) & 0x3) == uint8(IS_SIFF|CAPABILITY_UPDATE) {
-		var optionSlice []layers.IPv4Option = optionArray[:]
+		var optionSlice []layers.IPv4Option = optionArray[:2]
 		(*ipLayer).Options = optionSlice
 	} else if (uint8(flags) & 0x2) == uint8(IS_SIFF) {
 		var optionSlice []layers.IPv4Option = optionArray[:1]
@@ -180,10 +194,28 @@ func setCapabilities(packet *netfilter.NFPacket, capabilities []byte) {
 		ipLayer = layer.(*layers.IPv4)
 	}
 
-	var option layers.IPv4Option
+	// handle the options
+	var capOption layers.IPv4Option
+	capOption.OptionType = 86
+	capOption.OptionLength = uint8(len(capabilities)) + 2
+	capabilities = append(capabilities, 0)
+	capabilities = append(capabilities, 0)
+	capOption.OptionData = capabilities
 
-	option.OptionLength = uint8(len(capabilities))
-	option.OptionData = capabilities[:]
+	var option layers.IPv4Option
+	option.OptionType = 86
+	option.OptionLength = 8
+	
+	// set up a capabilities array
+	var capabilities_array [6]byte
+	for i, b := range capabilities {
+		capabilities_array[i] = b
+	}
+	for i := len(capabilities); i < 6; i++ {
+		capabilities_array[i] = 0
+	}
+
+	option.OptionData = capabilities_array[:]
 
 	// add into Options
 	(*ipLayer).Options[0] = option
@@ -200,7 +232,7 @@ func setUpdates(packet *netfilter.NFPacket, updates []byte) {
 
 	var option layers.IPv4Option
 
-	option.OptionLength = uint8(len(updates))
+	option.OptionLength = 8
 	option.OptionData = updates[:]
 
 	// add into Options
@@ -217,7 +249,7 @@ func getCapabilities(packet *netfilter.NFPacket) []byte {
 	}
 
 	if (*ipLayer).Options != nil {
-		return (*ipLayer).Options[0].OptionData
+		return (*ipLayer).Options[0].OptionData[:4]
 	} else {
 		return nil
 	}
@@ -233,7 +265,7 @@ func getUpdates(packet *netfilter.NFPacket) []byte {
 	}
 
 	if (*ipLayer).Options != nil {
-		return (*ipLayer).Options[1].OptionData
+		return (*ipLayer).Options[1].OptionData[:4]
 	} else {
 		return nil
 	}
@@ -249,26 +281,41 @@ func addCapability(packet *netfilter.NFPacket, capability byte) {
 	}
 
 	if (*ipLayer).Options != nil {
-		if (*ipLayer).Options[0].OptionLength == 4 {
+
+		var count int = 0
+		// count number of capabilities
+		for _, b := range(*ipLayer).Options[0].OptionData {
+			if b != 0 {
+				count = count + 1
+			}
+		}
+
+		if count == 4 {
 			// shift options forward
-			var capability_array [4]byte
+			var capability_array [6]byte
 			capability_array[0] = (*ipLayer).Options[0].OptionData[1]
 			capability_array[1] = (*ipLayer).Options[0].OptionData[2]
 			capability_array[2] = (*ipLayer).Options[0].OptionData[3]
 			capability_array[3] = capability
+			// copy over two padding bytes
+			capability_array[4] = (*ipLayer).Options[0].OptionData[4]
+			capability_array[5] = (*ipLayer).Options[0].OptionData[5]
 
 			(*ipLayer).Options[0].OptionData = capability_array[:]
 		} else {
-			var capability_array [4]byte
+			var capability_array [6]byte
+			var first_empty int = -1
 			// copy slice in optionData to array
 			for i, b := range (*ipLayer).Options[0].OptionData {
 				capability_array[i] = b
+				if b = 0 && first_empty == -1 {
+					first_empty = i
+				}
 			}
 			// store new capability
-			capability_array[(*ipLayer).Options[0].OptionLength] = capability
+			capability_array[first_empty] = capability
 			// set new slice
-			(*ipLayer).Options[0].OptionLength = (*ipLayer).Options[0].OptionLength + 1
-			(*ipLayer).Options[0].OptionData = capability_array[:(*ipLayer).Options[0].OptionLength]
+			(*ipLayer).Options[0].OptionData = capability_array[:]
 		}
 	}
 }
@@ -278,31 +325,42 @@ func addUpdate(packet *netfilter.NFPacket, capability byte) {
 
 	/* Get the IPv4 layer, and if it doesn't exist, keep doing shit
 	   I can't be arsed for proper response outside the bounds of this project */
-	if layer := (*packet).Packet.Layer(layers.LayerTypeIPv4); layer != nil {
-		ipLayer = layer.(*layers.IPv4)
-	}
-
 	if (*ipLayer).Options != nil {
-		if (*ipLayer).Options[1].OptionLength == 4 {
+
+		var count int = 0
+		// count number of capabilities
+		for _, b := range(*ipLayer).Options[1].OptionData {
+			if b != 0 {
+				count = count + 1
+			}
+		}
+
+		if count == 4 {
 			// shift options forward
-			var capability_array [4]byte
+			var capability_array [6]byte
 			capability_array[0] = (*ipLayer).Options[1].OptionData[1]
 			capability_array[1] = (*ipLayer).Options[1].OptionData[2]
 			capability_array[2] = (*ipLayer).Options[1].OptionData[3]
 			capability_array[3] = capability
+			// copy over two padding bytes
+			capability_array[4] = (*ipLayer).Options[1].OptionData[4]
+			capability_array[5] = (*ipLayer).Options[1].OptionData[5]
 
 			(*ipLayer).Options[1].OptionData = capability_array[:]
 		} else {
-			var capability_array [4]byte
+			var capability_array [6]byte
+			var first_empty int = -1
 			// copy slice in optionData to array
 			for i, b := range (*ipLayer).Options[1].OptionData {
 				capability_array[i] = b
+				if b = 0 && first_empty == -1 {
+					first_empty = i
+				}
 			}
 			// store new capability
-			capability_array[(*ipLayer).Options[1].OptionLength] = capability
+			capability_array[first_empty] = capability
 			// set new slice
-			(*ipLayer).Options[1].OptionLength = (*ipLayer).Options[1].OptionLength + 1
-			(*ipLayer).Options[1].OptionData = capability_array[:(*ipLayer).Options[1].OptionLength]
+			(*ipLayer).Options[1].OptionData = capability_array[:]
 		}
 	}
 }


### PR DESCRIPTION
So I've finished fixing all the functions - it counts the number of non-empty capability and update fields so that it still pads the options up to 8 bytes, but doesn't break if less than 4 capabilities are passed in. The same goes for the cap updates.

It's still limited to a max of 4 capabilities and 4 updates, but with the expanded space we need for the padding, we could easily bump that up to 6. Though it isn't necessary for the simulation to do so.
